### PR TITLE
Compromise to simplifying config objects

### DIFF
--- a/docs/ConfigObjects.md
+++ b/docs/ConfigObjects.md
@@ -2,6 +2,12 @@
 
 Config objects are any files in a package that are used for configuring the package by the end user. The benefit with the implementation of config objects is that any file extension can be a config object, even `fpp` files! The only requirement is that the file must be listed within the `package.yaml`, and that special [cookiecutter](https://cookiecutter.readthedocs.io/en/stable/) syntax is used.
 
+## Language
+
+- **Config Object**: The file that may (or may not) contain cookiecutter syntax to configure something about the package.
+- **Fillables**: YAML-files that allow end users to fill in cookiecutter variables
+- **Metavars**: Metadata variables that *could* be modified by the end user, but most likely are not.
+
 ## package.yaml
 
 Within the `package.yaml` file, a variable called `config_objects` can be created that includes a list of all of the config objects in the package, with relative paths. For example:
@@ -19,6 +25,11 @@ config_objects:
 ## "cookiecutter" syntax
 
 As you can see in the above example, cookiecutter syntax can be used within the file name, and also within the file itself. Variables are determined by `{{ cookiecutter.<VARIABLE_NAME> }}`, primarily so that the cookiecutter Python framework can be used to fill in the files.
+
+> [!IMPORTANT]
+> If you have used `cookiecutter` in the past, you may know that there are other folders and files that contribute to a cookiecutter object. Note that you do *not* need to provide any other cookiecutter files. Using template variables in your config objects is sufficient.
+
+*However*, config objects can also be free from any cookiecutter or special syntax. In this case, files will be passed straight through to the F Prime [`config/`](https://github.com/nasa/fprime/tree/devel/config) folder on `fppm config --generate`. This is useful if your package only contains config that can be done through an FPP file, for example.
 
 Let's take a look at an example config object, `{{cookiecutter.td_name}}TopologyDefs.hpp`. The file includes:
 
@@ -56,3 +67,48 @@ td_name: << FILL IN >>
 ```
 
 The user can then complete this file, and run `fppm config --apply` on the package to apply this yaml file and cookiecutter to create the final output file. The user should be told where the output files should go, and the best place to put this would be in the package design document.
+
+## Metadata Variables (Metavars)
+
+Metavars are bits of metadata that you can ship in your config object. These are predominantly only good for `fppm`, but there may be a time where your end user may want to edit these. Metavars transfer over to the config object's fillable, and are written with similar annotation syntax as the config object description:
+
+- `@! output = <path>` is the path where the generated config file from the fillable is moved to.
+- `@! pre_hook = <path/to/pythonScript.py>` is the path to your prehook script.
+- `@! post_hook = <path/to/pythonScript.py>` is the path to your posthook script.
+
+> [!IMPORTANT]
+> Note that currently, pre and post hooks are not yet implemented, as designs for them and security considerations are being considered.
+
+Let's take the above `TopologyDefs.hpp` example and add the `output` metavar to it:
+
+```cpp
+@! begin config description
+td_name is the name of the topology that is instantiated in your main deployment.
+@! end config description
+
+@! output = myCustomFolder // paths are relative to project root
+
+#ifndef TELEMETRY_DEFS_HPP
+#define TELEMETRY_DEFS_HPP
+
+...
+
+#endif
+```
+
+The updated metadata portion of the fillable for it looks like:
+
+```yaml
+# === START METADATA: DO NOT EDIT ===
+
+__package_path: _fprime_packages/mosallaei.TlmPacketizer
+__config_object: Telemetry/{{cookiecutter.td_name}}TopologyDefs.hpp
+
+# === METADATA VARIABLES: Do not edit if you don't know what you're doing! ===
+
+__output: myCustomFolder
+
+# === END METADATA ===
+```
+
+Note that files that do not have cookiecutter variables *can still* have metavars.

--- a/src/fppm/cli/commands/config.py
+++ b/src/fppm/cli/commands/config.py
@@ -236,7 +236,7 @@ def generate_config_fillables(args, context):
             configDir = str(settings['config_directory'])
             
             if "fprime" in configDir.split("/"):
-                print(f"{FppmUtils.bcolors.FAIL}[ERR]: No output directory specified for config object [{configObject}], and F Prime config folder not copied.{FppmUtils.bcolors.ENDC}")
+                print(f"{FppmUtils.bcolors.FAIL}[ERR]: No output directory specified for config object [{configObject}], and F Prime config folder not configured in settings.ini.{FppmUtils.bcolors.ENDC}")
                 return 1
             else:
                 shutil.copy(
@@ -244,6 +244,10 @@ def generate_config_fillables(args, context):
                     f"{configDir}"
                 )
                 print(f"{FppmUtils.bcolors.OKGREEN}[DONE]: Moved config object [{configObject}] to [{configDir}].{FppmUtils.bcolors.ENDC}")
+            
+                if ".fpp" in configObject:
+                    print(f"{FppmUtils.bcolors.WARNING}[WARN]: Output file {configObject} is an FPP file; remember to add it as a source in CMakeLists.txt.{FppmUtils.bcolors.ENDC}")
+                    
                 continue
 
         create_fillable(

--- a/src/fppm/cli/router.py
+++ b/src/fppm/cli/router.py
@@ -6,6 +6,7 @@ import fppm.cli.commands.install as cmd_install
 import fppm.cli.commands.config as cmd_config
 import fppm.cli.commands.remove as cmd_remove
 import sys
+from fppm.cli.utils import bcolors
 
 ROUTER = {
     "new": cmd_new.create_new_package_yml,
@@ -24,8 +25,8 @@ def route_commands(command, args: list) -> int:
             sys.exit(1)
         return 0
     except KeyError as e:
-        print(f"[ERR]: {e}")
+        print(f"{bcolors.FAIL}[ERR]: {e}{bcolors.ENDC}")
         sys.exit(1)
     except Exception as e:
-        print(f"[ERR]: {e}")
+        print(f"{bcolors.FAIL}[ERR]: {e}{bcolors.ENDC}")
         sys.exit(1)

--- a/src/fppm/cli/utils.py
+++ b/src/fppm/cli/utils.py
@@ -1,3 +1,5 @@
+from fprime.fbuild.settings import IniSettings
+
 def is_valid_name(word: str):
     invalid_characters = [
         "#",
@@ -29,3 +31,34 @@ def is_valid_name(word: str):
         if not isinstance(word, str):
             raise ValueError("Incorrect usage of is_valid_name")
     return "valid"
+
+class bcolors:
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKCYAN = '\033[96m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
+
+def prompt(msg, options):
+    response = input(bcolors.BOLD + msg + bcolors.ENDC)
+    
+    if response in options:
+        return response
+    else:
+        print(f"{bcolors.FAIL}Invalid option {response}, try again.{bcolors.ENDC}")
+        return prompt(msg, options)
+
+def openSettingsIni(path):
+    try:
+        with open(path, "r") as file:
+            file.close()
+    except FileNotFoundError:
+        print(f"{bcolors.FAIL}The file {path} does not exist.{bcolors.ENDC}")
+        return None
+    
+    settings = IniSettings()
+    return settings.load(path)


### PR DESCRIPTION
Config objects have been simplified only to an extent, not to the degree specified by #1. 

Now, config objects can include files that do not have any variables that need modifications. In that case, these config objects will be tossed into the F Prime configs folder.

Closes #1 