### PR TITLE
bug: Fix installing packages with version tag

### DIFF
--- a/src/fppm/cli/commands/install.py
+++ b/src/fppm/cli/commands/install.py
@@ -217,9 +217,7 @@ def install_package(args, context):
                         [
                             "git",
                             "checkout",
-                            f"tags/{packageVersion}",
-                            "--branch",
-                            package["info"]["branch"],
+                            f"tags/{packageVersion}"
                         ],
                         stderr=subprocess.PIPE,
                         stdout=subprocess.PIPE,


### PR DESCRIPTION
Installing packages with a version flag caused a 129 error when checking out with git (within `fppm`). This was because extra flags for determining the branch of the tag were passed. This was removed in package updates, but not in package installs.